### PR TITLE
When fallback policy check succeeds, then verification result errorCode should be null.

### DIFF
--- a/ksi-api/src/test/java/com/guardtime/ksi/KSITest.java
+++ b/ksi-api/src/test/java/com/guardtime/ksi/KSITest.java
@@ -28,7 +28,9 @@ import com.guardtime.ksi.service.http.simple.SimpleHttpClient;
 import com.guardtime.ksi.trust.X509CertificateSubjectRdnSelector;
 import com.guardtime.ksi.unisignature.KSISignature;
 import com.guardtime.ksi.unisignature.verifier.VerificationResult;
+import com.guardtime.ksi.unisignature.verifier.policies.AlwaysFailingDummyPolicy;
 import com.guardtime.ksi.unisignature.verifier.policies.KeyBasedVerificationPolicy;
+import com.guardtime.ksi.unisignature.verifier.policies.Policy;
 import com.guardtime.ksi.unisignature.verifier.policies.PublicationsFileBasedVerificationPolicy;
 import com.guardtime.ksi.util.Base16;
 import org.testng.Assert;
@@ -165,10 +167,21 @@ public class KSITest {
     }
 
     @Test
+    public void testVerifySignatureWithFallbackPolicy_OK() throws Exception {
+        KSISignature signature = ksi.read(TestUtil.load("ok-sig-2014-04-30.1.ksig"));
+        Policy policy = new AlwaysFailingDummyPolicy();
+        policy.setFallbackPolicy( new KeyBasedVerificationPolicy() );
+        VerificationResult result = ksi.verify(signature, policy);
+        Assert.assertTrue(result.isOk());
+        Assert.assertNull(result.getErrorCode());
+    }
+
+    @Test
     public void testVerifySignatureWithFileDataHashWithoutContext_OK() throws Exception {
         KSISignature signature = ksi.read(TestUtil.load("ok-sig-2014-04-30.1.ksig"));
         VerificationResult result = ksi.verify(signature, new KeyBasedVerificationPolicy(), new DataHash(HashAlgorithm.SHA2_256, Base16.decode("11A700B0C8066C47ECBA05ED37BC14DCADB238552D86C659342D1D7E87B8772D")));
         Assert.assertTrue(result.isOk());
+        Assert.assertNull(result.getErrorCode());
     }
 
     @Test
@@ -176,6 +189,7 @@ public class KSITest {
         KSISignature signature = ksi.read(TestUtil.load("ok-sig-2014-06-2-extended.ksig"));
         VerificationResult result = ksi.verify(signature, new PublicationsFileBasedVerificationPolicy());
         Assert.assertTrue(result.isOk());
+        Assert.assertNull(result.getErrorCode());
     }
 
     @Test
@@ -185,7 +199,7 @@ public class KSITest {
         DataHash documentHash = new DataHash(HashAlgorithm.SHA2_256, Base16.decode("11A700B0C8066C47ECBA05ED37BC14DCADB238552D86C659342D1D7E87B8772D"));
         VerificationResult result = ksi.verify(signature, new PublicationsFileBasedVerificationPolicy(), documentHash, publicationData);
         Assert.assertTrue(result.isOk());
+        Assert.assertNull(result.getErrorCode());
     }
-
 
 }

--- a/ksi-api/src/test/java/com/guardtime/ksi/unisignature/verifier/policies/AlwaysFailingDummyPolicy.java
+++ b/ksi-api/src/test/java/com/guardtime/ksi/unisignature/verifier/policies/AlwaysFailingDummyPolicy.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013-2015 Guardtime, Inc.
+ *
+ * This file is part of the Guardtime client SDK.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES, CONDITIONS, OR OTHER LICENSES OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ * "Guardtime" and "KSI" are trademarks or registered trademarks of
+ * Guardtime, Inc., and no license to trademarks is granted; Guardtime
+ * reserves and retains all trademark rights.
+ */
+
+package com.guardtime.ksi.unisignature.verifier.policies;
+
+import com.guardtime.ksi.unisignature.verifier.rules.AlwaysFailingDummyRule;
+
+/**
+ * This policy is used to test signature verification failures in tests.
+ */
+public class AlwaysFailingDummyPolicy extends InternalVerificationPolicy {
+
+    public AlwaysFailingDummyPolicy() {
+        addRule( new AlwaysFailingDummyRule() );
+    }
+
+    public String getName(){
+        return "Always failing dummy policy";
+    }
+
+    public String getType(){
+        return "FAILING";
+    }
+}

--- a/ksi-api/src/test/java/com/guardtime/ksi/unisignature/verifier/rules/AlwaysFailingDummyRule.java
+++ b/ksi-api/src/test/java/com/guardtime/ksi/unisignature/verifier/rules/AlwaysFailingDummyRule.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2013-2015 Guardtime, Inc.
+ *
+ * This file is part of the Guardtime client SDK.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES, CONDITIONS, OR OTHER LICENSES OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ * "Guardtime" and "KSI" are trademarks or registered trademarks of
+ * Guardtime, Inc., and no license to trademarks is granted; Guardtime
+ * reserves and retains all trademark rights.
+ */
+
+package com.guardtime.ksi.unisignature.verifier.rules;
+
+import com.guardtime.ksi.exceptions.KSIException;
+import com.guardtime.ksi.unisignature.verifier.VerificationContext;
+import com.guardtime.ksi.unisignature.verifier.VerificationErrorCode;
+import com.guardtime.ksi.unisignature.verifier.VerificationResultCode;
+
+/**
+ * This rule is used to test signature verification failures in tests.
+ */
+public class AlwaysFailingDummyRule extends BaseRule {
+
+    public VerificationResultCode verifySignature(VerificationContext context) throws KSIException {
+        return VerificationResultCode.NA;
+    }
+
+    public VerificationErrorCode getErrorCode() {
+        return VerificationErrorCode.INT_01;
+    }
+}


### PR DESCRIPTION
When primary policy fails, but fallback policy passes, the VerificationResult ok is true, but errorCode is preserved from primary policy failure.

I created failing testcase, but did not change the code.